### PR TITLE
Use fallback-x11 instead of x11

### DIFF
--- a/net.sourceforge.QtSpim.yaml
+++ b/net.sourceforge.QtSpim.yaml
@@ -7,7 +7,7 @@ finish-args:
   - '--device=dri'
   - '--share=ipc'
   - '--share=network'
-  - '--socket=x11'
+  - '--socket=fallback-x11'
   - '--socket=wayland'
 modules:
   - name: qtspim


### PR DESCRIPTION
Works fine like this too, so no need to always allow the X11 socket.